### PR TITLE
Improvements to bench tests

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -298,7 +298,7 @@ mod bench_tests {
     }
 
     #[bench]
-    fn bench_sokoban_avl_tree_remove_u128(b: &mut Bencher) {
+    fn bench_sokoban_avl_tree_remove_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
         let mut buf = vec![0u8; std::mem::size_of::<AVLTreeMap>()];
         let m = AVLTreeMap::new_from_slice(buf.as_mut_slice());

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -220,10 +220,10 @@ mod bench_tests {
         let mut m = BTreeMap::new();
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
+        for v in 0..1000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
         b.iter(|| {
-            for v in 0..1000 {
-                m.insert(v as u128, rng.gen::<u128>());
-            }
             for k in slice.iter() {
                 m.remove(k);
             }
@@ -236,10 +236,10 @@ mod bench_tests {
         let mut m = HashMap::new();
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
+        for v in 0..1000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
         b.iter(|| {
-            for v in 0..1000 {
-                m.insert(v as u128, rng.gen::<u128>());
-            }
             for k in slice.iter() {
                 m.remove(k);
             }
@@ -253,10 +253,10 @@ mod bench_tests {
         let m = RBTree::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
+        for v in 0..1000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
         b.iter(|| {
-            for v in 0..1000 {
-                m.insert(v as u128, rng.gen::<u128>());
-            }
             for k in slice.iter() {
                 m.remove(k);
             }
@@ -270,10 +270,10 @@ mod bench_tests {
         let m = SHashMap::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
+        for v in 0..1000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
         b.iter(|| {
-            for v in 0..1000 {
-                m.insert(v as u128, rng.gen::<u128>());
-            }
             for k in slice.iter() {
                 m.remove(k);
             }
@@ -287,10 +287,10 @@ mod bench_tests {
         let m = CritbitTree::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
+        for v in 0..1000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
         b.iter(|| {
-            for v in 0..1000 {
-                m.insert(v as u128, rng.gen::<u128>());
-            }
             for k in slice.iter() {
                 m.remove(k);
             }
@@ -304,10 +304,10 @@ mod bench_tests {
         let m = AVLTreeMap::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
+        for v in 0..1000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
         b.iter(|| {
-            for v in 0..1000 {
-                m.insert(v as u128, rng.gen::<u128>());
-            }
             for k in slice.iter() {
                 m.remove(k);
             }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -313,4 +313,93 @@ mod bench_tests {
             }
         })
     }
+
+
+    #[bench]
+    fn bench_std_btree_map_lookup_20000_u128(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut m = BTreeMap::new();
+        for v in 0..20000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
+        b.iter(|| {
+            for v in 0..20000 {
+                m.get(&v);
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_std_hash_map_lookup_20000_u128(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut m = HashMap::new();
+        for v in 0..20000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
+        b.iter(|| {
+            for v in 0..20000 {
+                m.get(&v);
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_sokoban_red_black_tree_lookup_20000_u128(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0u8; std::mem::size_of::<RBTree>()];
+        let m = RBTree::new_from_slice(buf.as_mut_slice());
+        for v in 0..20000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
+        b.iter(|| {
+            for v in 0..20000 {
+                m.get(&v);
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_sokoban_hash_map_lookup_20000_u128(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0u8; std::mem::size_of::<SHashMap>()];
+        let m = SHashMap::new_from_slice(buf.as_mut_slice());
+        for v in 0..20000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
+        b.iter(|| {
+            for v in 0..20000 {
+                m.get(&v);
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_sokoban_critbit_lookup_20000_u128(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0u8; std::mem::size_of::<CritbitTree>()];
+        let m = CritbitTree::new_from_slice(buf.as_mut_slice());
+        for v in 0..20000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
+        b.iter(|| {
+            for v in 0..20000 {
+                m.get(&v);
+            }
+        })
+    }
+
+    #[bench]
+    fn bench_sokoban_avl_tree_lookup_20000_u128(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0u8; std::mem::size_of::<AVLTreeMap>()];
+        let m = AVLTreeMap::new_from_slice(buf.as_mut_slice());
+        for v in 0..20000 {
+            m.insert(v as u128, rng.gen::<u128>());
+        }
+        b.iter(|| {
+            for v in 0..20000 {
+                m.get(&v);
+            }
+        })
+    }
 }


### PR DESCRIPTION
This PR includes changes to the bench tests to:
1. Change the label of `bench_sokoban_avl_tree_remove_u128` to `bench_sokoban_avl_tree_remove_1000_u128` to match the name of the other remove tests.
2. Move the insert step outside of the benchmark on the remove tests, so the measure only includes the time to remove the items.
3. Add lookup tests.

```
test bench_tests::bench_sokoban_avl_tree_insert_1000_u128             ... bench:      95,849 ns/iter (+/- 3,441)
test bench_tests::bench_sokoban_avl_tree_insert_1000_u128_stack       ... bench:     108,724 ns/iter (+/- 1,801)
test bench_tests::bench_sokoban_avl_tree_insert_20000_u128            ... bench:   2,175,486 ns/iter (+/- 26,504)
test bench_tests::bench_sokoban_avl_tree_lookup_20000_u128            ... bench:     946,922 ns/iter (+/- 22,870)
test bench_tests::bench_sokoban_avl_tree_remove_1000_u128             ... bench:       1,874 ns/iter (+/- 139)
test bench_tests::bench_sokoban_critbit_insert_1000_u128              ... bench:      65,728 ns/iter (+/- 1,217)
test bench_tests::bench_sokoban_critbit_insert_1000_u128_stack        ... bench:      66,342 ns/iter (+/- 2,142)
test bench_tests::bench_sokoban_critbit_insert_20000_u128             ... bench:   1,963,832 ns/iter (+/- 84,912)
test bench_tests::bench_sokoban_critbit_lookup_20000_u128             ... bench:   1,652,995 ns/iter (+/- 28,951)
test bench_tests::bench_sokoban_critbit_remove_1000_u128              ... bench:       2,110 ns/iter (+/- 22)
test bench_tests::bench_sokoban_hash_map_insert_1000_u128             ... bench:      28,473 ns/iter (+/- 476)
test bench_tests::bench_sokoban_hash_map_insert_1000_u128_stack       ... bench:      28,533 ns/iter (+/- 473)
test bench_tests::bench_sokoban_hash_map_insert_20000_u128            ... bench:   1,033,449 ns/iter (+/- 10,907)
test bench_tests::bench_sokoban_hash_map_lookup_20000_u128            ... bench:     825,924 ns/iter (+/- 35,330)
test bench_tests::bench_sokoban_hash_map_remove_1000_u128             ... bench:      13,045 ns/iter (+/- 665)
test bench_tests::bench_sokoban_red_black_tree_insert_1000_u128       ... bench:      49,026 ns/iter (+/- 549)
test bench_tests::bench_sokoban_red_black_tree_insert_1000_u128_stack ... bench:      49,218 ns/iter (+/- 859)
test bench_tests::bench_sokoban_red_black_tree_insert_20000_u128      ... bench:   1,450,428 ns/iter (+/- 24,906)
test bench_tests::bench_sokoban_red_black_tree_lookup_20000_u128      ... bench:   1,043,305 ns/iter (+/- 141,596)
test bench_tests::bench_sokoban_red_black_tree_remove_1000_u128       ... bench:       2,275 ns/iter (+/- 143)
test bench_tests::bench_std_btree_map_insert_1000_u128                ... bench:      39,719 ns/iter (+/- 465)
test bench_tests::bench_std_btree_map_insert_20000_u128               ... bench:     971,612 ns/iter (+/- 12,728)
test bench_tests::bench_std_btree_map_lookup_20000_u128               ... bench:     987,608 ns/iter (+/- 22,162)
test bench_tests::bench_std_btree_map_remove_1000_u128                ... bench:       1,201 ns/iter (+/- 10)
test bench_tests::bench_std_hash_map_insert_1000_u128                 ... bench:      20,465 ns/iter (+/- 462)
test bench_tests::bench_std_hash_map_insert_20000_u128                ... bench:     484,015 ns/iter (+/- 9,921)
test bench_tests::bench_std_hash_map_lookup_20000_u128                ... bench:     315,190 ns/iter (+/- 12,477)
test bench_tests::bench_std_hash_map_remove_1000_u128                 ... bench:      11,380 ns/iter (+/- 217)

test result: ok. 0 passed; 0 failed; 0 ignored; 28 measured; 0 filtered out; finished in 61.36s
```