### PR TITLE
feat: make lib `no_std` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,17 @@ crate-type = ["lib"]
 required-features = []
 
 [dependencies]
-bytemuck = "1.13.0"
-thiserror = "1.0.38"
-num-derive = "0.3.3"
+thiserror = { version = "2.0.17", default-features = false }
+bytemuck = "1.24.0"
+num-derive = "0.4.2"
 num-traits = "0.2.15"
+libc-print = "0.1.23"
+hashbrown = { version = "0.16.0", default-features = false, features = [
+    "default-hasher",
+] }
 
 [dev-dependencies]
 rand_distr = "0.4.3"
-itertools = "0.10.3"
+itertools = "0.14.0"
 rand = "0.7"
-tokio = { version = "1.8.4", features = ["full"] }
+tokio = { version = "1.48.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,12 @@ crate-type = ["lib"]
 required-features = []
 
 [dependencies]
+foldhash = { version = "0.2.0", default-features = false }
 thiserror = { version = "2.0.17", default-features = false }
 bytemuck = "1.24.0"
 num-derive = "0.4.2"
 num-traits = "0.2.15"
 libc-print = "0.1.23"
-hashbrown = { version = "0.16.0", default-features = false, features = [
-    "default-hasher",
-] }
 
 [dev-dependencies]
 rand_distr = "0.4.3"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,6 @@
 #![feature(test)]
 
+extern crate std;
 extern crate test;
 
 #[cfg(test)]
@@ -55,7 +56,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_red_black_tree_insert_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<RBTree1K>()];
+        let mut buf = vec![0u8; core::mem::size_of::<RBTree1K>()];
         let m = RBTree1K::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..1000 {
@@ -67,7 +68,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_hash_map_insert_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<SHashMap1K>()];
+        let mut buf = vec![0u8; core::mem::size_of::<SHashMap1K>()];
         let m = SHashMap1K::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..1000 {
@@ -79,7 +80,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_critbit_insert_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<CritbitTree1K>()];
+        let mut buf = vec![0u8; core::mem::size_of::<CritbitTree1K>()];
         let m = CritbitTree1K::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..1000 {
@@ -91,7 +92,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_avl_tree_insert_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<AVLTreeMap1K>()];
+        let mut buf = vec![0u8; core::mem::size_of::<AVLTreeMap1K>()];
         let m = AVLTreeMap1K::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..1000 {
@@ -169,7 +170,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_red_black_tree_insert_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<RBTree>()];
+        let mut buf = vec![0u8; core::mem::size_of::<RBTree>()];
         let m = RBTree::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..20000 {
@@ -181,7 +182,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_hash_map_insert_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<SHashMap>()];
+        let mut buf = vec![0u8; core::mem::size_of::<SHashMap>()];
         let m = SHashMap::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..20000 {
@@ -193,7 +194,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_critbit_insert_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<CritbitTree>()];
+        let mut buf = vec![0u8; core::mem::size_of::<CritbitTree>()];
         let m = CritbitTree::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..20000 {
@@ -205,7 +206,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_avl_tree_insert_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<AVLTreeMap>()];
+        let mut buf = vec![0u8; core::mem::size_of::<AVLTreeMap>()];
         let m = AVLTreeMap::new_from_slice(buf.as_mut_slice());
         b.iter(|| {
             for v in 0..20000 {
@@ -249,7 +250,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_red_black_tree_remove_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<RBTree>()];
+        let mut buf = vec![0u8; core::mem::size_of::<RBTree>()];
         let m = RBTree::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
@@ -266,7 +267,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_hash_map_remove_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<SHashMap>()];
+        let mut buf = vec![0u8; core::mem::size_of::<SHashMap>()];
         let m = SHashMap::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
@@ -283,7 +284,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_critbit_remove_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<CritbitTree>()];
+        let mut buf = vec![0u8; core::mem::size_of::<CritbitTree>()];
         let m = CritbitTree::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
@@ -300,7 +301,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_avl_tree_remove_1000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<AVLTreeMap>()];
+        let mut buf = vec![0u8; core::mem::size_of::<AVLTreeMap>()];
         let m = AVLTreeMap::new_from_slice(buf.as_mut_slice());
         let mut slice: Vec<u128> = (0..1000).collect();
         slice.shuffle(&mut rng);
@@ -313,7 +314,6 @@ mod bench_tests {
             }
         })
     }
-
 
     #[bench]
     fn bench_std_btree_map_lookup_20000_u128(b: &mut Bencher) {
@@ -346,7 +346,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_red_black_tree_lookup_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<RBTree>()];
+        let mut buf = vec![0u8; core::mem::size_of::<RBTree>()];
         let m = RBTree::new_from_slice(buf.as_mut_slice());
         for v in 0..20000 {
             m.insert(v as u128, rng.gen::<u128>());
@@ -361,7 +361,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_hash_map_lookup_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<SHashMap>()];
+        let mut buf = vec![0u8; core::mem::size_of::<SHashMap>()];
         let m = SHashMap::new_from_slice(buf.as_mut_slice());
         for v in 0..20000 {
             m.insert(v as u128, rng.gen::<u128>());
@@ -376,7 +376,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_critbit_lookup_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<CritbitTree>()];
+        let mut buf = vec![0u8; core::mem::size_of::<CritbitTree>()];
         let m = CritbitTree::new_from_slice(buf.as_mut_slice());
         for v in 0..20000 {
             m.insert(v as u128, rng.gen::<u128>());
@@ -391,7 +391,7 @@ mod bench_tests {
     #[bench]
     fn bench_sokoban_avl_tree_lookup_20000_u128(b: &mut Bencher) {
         let mut rng = rand::thread_rng();
-        let mut buf = vec![0u8; std::mem::size_of::<AVLTreeMap>()];
+        let mut buf = vec![0u8; core::mem::size_of::<AVLTreeMap>()];
         let m = AVLTreeMap::new_from_slice(buf.as_mut_slice());
         for v in 0..20000 {
             m.insert(v as u128, rng.gen::<u128>());

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,11 +1,11 @@
 use arbitrary::Arbitrary;
+use core::{cmp::PartialEq, fmt::Debug};
 use rand::thread_rng;
 use rand::Rng;
 use sokoban::NodeAllocatorMap;
-use std::fmt::Debug;
 
 #[derive(Debug, Arbitrary, Clone, Copy)]
-pub enum NodeAllocatorMapAction<K: Copy, V: std::fmt::Debug + std::cmp::PartialEq + Copy> {
+pub enum NodeAllocatorMapAction<K: Copy, V: Debug + PartialEq + Copy> {
     Insert { key: K, value: V },
     Upsert { value: V },
     Remove,
@@ -16,7 +16,7 @@ pub enum NodeAllocatorMapAction<K: Copy, V: std::fmt::Debug + std::cmp::PartialE
     IterMutRev,
 }
 
-pub fn perform_action<K: Copy, V: std::fmt::Debug + std::cmp::PartialEq + Copy>(
+pub fn perform_action<K: Copy, V: Debug + PartialEq + Copy>(
     tree: &mut dyn NodeAllocatorMap<K, V>,
     keys: &mut Vec<K>,
     action: NodeAllocatorMapAction<K, V>,

--- a/src/avl_tree.rs
+++ b/src/avl_tree.rs
@@ -57,7 +57,7 @@ impl<
         V: Default + Copy + Clone + Pod + Zeroable,
     > AVLNode<K, V>
 {
-    pub fn new(key: K, value: V) -> Self {
+    pub const fn new(key: K, value: V) -> Self {
         Self { key, value }
     }
 }
@@ -253,11 +253,11 @@ impl<
         self.allocator.initialize()
     }
 
-    pub fn get_node(&self, node: u32) -> &AVLNode<K, V> {
+    pub const fn get_node(&self, node: u32) -> &AVLNode<K, V> {
         self.allocator.get(node).get_value()
     }
 
-    pub fn get_node_mut(&mut self, node: u32) -> &mut AVLNode<K, V> {
+    pub const fn get_node_mut(&mut self, node: u32) -> &mut AVLNode<K, V> {
         self.allocator.get_mut(node).get_value_mut()
     }
 
@@ -273,7 +273,7 @@ impl<
     }
 
     #[inline(always)]
-    fn get_field(&self, node: u32, register: Field) -> u32 {
+    const fn get_field(&self, node: u32, register: Field) -> u32 {
         self.allocator.get_register(node, register as u32)
     }
 
@@ -428,7 +428,7 @@ impl<
         Some(value)
     }
 
-    fn balance_factor(&self, left: u32, right: u32) -> i32 {
+    const fn balance_factor(&self, left: u32, right: u32) -> i32 {
         // safe to convert to i32 since height will be at most log2(capacity)
         let left_height = if left != SENTINEL {
             self.get_field(left, Field::Height) as i32 + 1
@@ -488,7 +488,7 @@ impl<
         self.set_field(index, Field::Height, height);
     }
 
-    fn delete(&mut self, node: u32) {
+    const fn delete(&mut self, node: u32) {
         self.allocator.clear_register(node, Field::Left as u32);
         self.allocator.clear_register(node, Field::Right as u32);
         self.allocator.clear_register(node, Field::Height as u32);
@@ -560,7 +560,7 @@ impl<
         }
     }
 
-    pub fn find_min_index(&self) -> u32 {
+    pub const fn find_min_index(&self) -> u32 {
         if self.root as u32 == SENTINEL {
             return SENTINEL;
         }
@@ -571,7 +571,7 @@ impl<
         node
     }
 
-    pub fn find_max_index(&self) -> u32 {
+    pub const fn find_max_index(&self) -> u32 {
         if self.root as u32 == SENTINEL {
             return SENTINEL;
         }
@@ -582,7 +582,7 @@ impl<
         node
     }
 
-    pub fn find_min(&self) -> Option<&V> {
+    pub const fn find_min(&self) -> Option<&V> {
         let node = self.find_min_index();
         if node == SENTINEL {
             None
@@ -591,7 +591,7 @@ impl<
         }
     }
 
-    pub fn find_max(&self) -> Option<&V> {
+    pub const fn find_max(&self) -> Option<&V> {
         let node = self.find_max_index();
         if node == SENTINEL {
             None
@@ -600,7 +600,7 @@ impl<
         }
     }
 
-    fn _iter(&self) -> AVLTreeIterator<'_, K, V, MAX_SIZE> {
+    const fn _iter(&self) -> AVLTreeIterator<'_, K, V, MAX_SIZE> {
         AVLTreeIterator::<K, V, MAX_SIZE> {
             tree: self,
             fwd_stack: vec![],
@@ -613,7 +613,7 @@ impl<
         }
     }
 
-    fn _iter_mut(&mut self) -> AVLTreeIteratorMut<'_, K, V, MAX_SIZE> {
+    const fn _iter_mut(&mut self) -> AVLTreeIteratorMut<'_, K, V, MAX_SIZE> {
         let node = self.root as u32;
         AVLTreeIteratorMut::<K, V, MAX_SIZE> {
             tree: self,

--- a/src/avl_tree.rs
+++ b/src/avl_tree.rs
@@ -1,5 +1,6 @@
+use alloc::{boxed::Box, vec, vec::Vec};
 use bytemuck::{Pod, Zeroable};
-use std::{
+use core::{
     cmp::max,
     ops::{Index, IndexMut},
 };
@@ -702,11 +703,10 @@ impl<
 }
 
 impl<
-        'a,
         K: PartialOrd + Copy + Clone + Default + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
         const MAX_SIZE: usize,
-    > DoubleEndedIterator for AVLTreeIterator<'a, K, V, MAX_SIZE>
+    > DoubleEndedIterator for AVLTreeIterator<'_, K, V, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while !self.terminated && (!self.rev_stack.is_empty() || self.rev_ptr != SENTINEL) {
@@ -786,11 +786,10 @@ impl<
 }
 
 impl<
-        'a,
         K: PartialOrd + Copy + Clone + Default + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
         const MAX_SIZE: usize,
-    > DoubleEndedIterator for AVLTreeIteratorMut<'a, K, V, MAX_SIZE>
+    > DoubleEndedIterator for AVLTreeIteratorMut<'_, K, V, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while !self.terminated && (!self.rev_stack.is_empty() || self.rev_ptr != SENTINEL) {

--- a/src/critbit.rs
+++ b/src/critbit.rs
@@ -1,5 +1,6 @@
+use alloc::{boxed::Box, vec, vec::Vec};
 use bytemuck::{Pod, Zeroable};
-use std::ops::{Index, IndexMut};
+use core::ops::{Index, IndexMut};
 
 use crate::node_allocator::{
     FromSlice, NodeAllocator, NodeAllocatorMap, OrderedNodeAllocatorMap, TreeField as Field,
@@ -130,7 +131,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
         if self.is_empty() {
             return None;
         }
-        let mut node_index = self.root as u32;
+        let mut node_index = self.root;
         loop {
             let node = self.get_node(node_index);
             if !self.is_inner_node(node_index) {
@@ -176,11 +177,11 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
     OrderedNodeAllocatorMap<u128, V> for Critbit<V, NUM_NODES, MAX_SIZE>
 {
     fn get_min_index(&mut self) -> u32 {
-        self.find_min(self.root as u32)
+        self.find_min(self.root)
     }
 
     fn get_max_index(&mut self) -> u32 {
-        self.find_max(self.root as u32)
+        self.find_max(self.root)
     }
 
     fn get_min(&mut self) -> Option<(u128, V)> {
@@ -384,7 +385,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
     }
 
     pub fn get_addr(&self, key: u128) -> u32 {
-        let mut node_index = self.root as u32;
+        let mut node_index = self.root;
         loop {
             let node = self.get_node(node_index);
             if !self.is_inner_node(node_index) {
@@ -635,12 +636,8 @@ impl<
     }
 }
 
-impl<
-        'a,
-        V: Default + Copy + Clone + Pod + Zeroable,
-        const MAX_NODES: usize,
-        const MAX_SIZE: usize,
-    > DoubleEndedIterator for CritbitIterator<'a, V, MAX_NODES, MAX_SIZE>
+impl<V: Default + Copy + Clone + Pod + Zeroable, const MAX_NODES: usize, const MAX_SIZE: usize>
+    DoubleEndedIterator for CritbitIterator<'_, V, MAX_NODES, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while !self.terminated && !self.rev_stack.is_empty() {
@@ -729,12 +726,8 @@ impl<
     }
 }
 
-impl<
-        'a,
-        V: Default + Copy + Clone + Pod + Zeroable,
-        const MAX_NODES: usize,
-        const MAX_SIZE: usize,
-    > DoubleEndedIterator for CritbitIteratorMut<'a, V, MAX_NODES, MAX_SIZE>
+impl<V: Default + Copy + Clone + Pod + Zeroable, const MAX_NODES: usize, const MAX_SIZE: usize>
+    DoubleEndedIterator for CritbitIteratorMut<'_, V, MAX_NODES, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while !self.terminated && !self.rev_stack.is_empty() {

--- a/src/critbit.rs
+++ b/src/critbit.rs
@@ -19,7 +19,7 @@ unsafe impl Zeroable for CritbitNode {}
 unsafe impl Pod for CritbitNode {}
 
 impl CritbitNode {
-    pub fn new(prefix_len: u64, key: u128) -> Self {
+    pub const fn new(prefix_len: u64, key: u128) -> Self {
         Self {
             prefix_len,
             key,
@@ -219,51 +219,51 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
         self.leaves.initialize();
     }
 
-    pub fn get_leaf(&self, leaf_index: u32) -> &V {
+    pub const fn get_leaf(&self, leaf_index: u32) -> &V {
         self.leaves.get(leaf_index).get_value()
     }
 
-    pub fn get_leaf_mut(&mut self, leaf_index: u32) -> &mut V {
+    pub const fn get_leaf_mut(&mut self, leaf_index: u32) -> &mut V {
         self.leaves.get_mut(leaf_index).get_value_mut()
     }
 
-    fn get_leaf_index(&self, node: u32) -> u32 {
+    const fn get_leaf_index(&self, node: u32) -> u32 {
         self.node_allocator.get_register(node, Field::Value as u32)
     }
 
-    pub fn is_inner_node(&self, node: u32) -> bool {
+    pub const fn is_inner_node(&self, node: u32) -> bool {
         self.node_allocator.get_register(node, Field::Value as u32) == SENTINEL
     }
 
-    pub fn get_node(&self, node: u32) -> CritbitNode {
+    pub const fn get_node(&self, node: u32) -> CritbitNode {
         *self.node_allocator.get(node).get_value()
     }
 
-    pub fn get_key(&self, node: u32) -> &u128 {
+    pub const fn get_key(&self, node: u32) -> &u128 {
         &self.node_allocator.get(node).get_value().key
     }
 
     #[inline(always)]
-    pub fn get_left(&self, node: u32) -> u32 {
+    pub const fn get_left(&self, node: u32) -> u32 {
         self.node_allocator.get_register(node, Field::Left as u32)
     }
 
     #[inline(always)]
-    pub fn get_right(&self, node: u32) -> u32 {
+    pub const fn get_right(&self, node: u32) -> u32 {
         self.node_allocator.get_register(node, Field::Right as u32)
     }
 
     #[inline(always)]
-    pub fn get_parent(&self, node: u32) -> u32 {
+    pub const fn get_parent(&self, node: u32) -> u32 {
         self.node_allocator.get_register(node, Field::Parent as u32)
     }
 
-    pub fn get_node_mut(&mut self, node: u32) -> &mut CritbitNode {
+    pub const fn get_node_mut(&mut self, node: u32) -> &mut CritbitNode {
         self.node_allocator.get_mut(node).get_value_mut()
     }
 
     #[inline(always)]
-    fn replace_leaf(&mut self, leaf_index: u32, value: V) {
+    const fn replace_leaf(&mut self, leaf_index: u32, value: V) {
         self.leaves.get_mut(leaf_index).set_value(value);
     }
 
@@ -278,7 +278,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
     }
 
     #[inline(always)]
-    fn get_child(&self, prefix_len: u64, node_index: u32, search_key: u128) -> (u32, bool) {
+    const fn get_child(&self, prefix_len: u64, node_index: u32, search_key: u128) -> (u32, bool) {
         let crit_bit_mask = (1u128 << 127) >> prefix_len;
         if (search_key & crit_bit_mask) != 0 {
             (self.get_right(node_index), true)
@@ -305,7 +305,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
     }
 
     #[inline(always)]
-    fn replace_node(
+    const fn replace_node(
         &mut self,
         node_index: u32,
         node_contents: &CritbitNode,
@@ -384,7 +384,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
         value
     }
 
-    pub fn get_addr(&self, key: u128) -> u32 {
+    pub const fn get_addr(&self, key: u128) -> u32 {
         let mut node_index = self.root;
         loop {
             let node = self.get_node(node_index);
@@ -494,7 +494,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
         Some(leaf)
     }
 
-    fn find_min(&self, index: u32) -> u32 {
+    const fn find_min(&self, index: u32) -> u32 {
         let mut node = index;
         while self.get_left(node) != SENTINEL {
             node = self.get_left(node);
@@ -502,7 +502,7 @@ impl<V: Default + Copy + Clone + Pod + Zeroable, const NUM_NODES: usize, const M
         node
     }
 
-    fn find_max(&self, index: u32) -> u32 {
+    const fn find_max(&self, index: u32) -> u32 {
         let mut node = index;
         while self.get_right(node) != SENTINEL {
             node = self.get_right(node);

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -137,8 +137,8 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
             let right = self.get_next(i);
             (left, right, value)
         };
-        self.allocator.clear_register(i as u32, PREV);
-        self.allocator.clear_register(i as u32, NEXT);
+        self.allocator.clear_register(i, PREV);
+        self.allocator.clear_register(i, NEXT);
         if left != SENTINEL && right != SENTINEL {
             self.allocator.connect(left, right, NEXT, PREV);
         }
@@ -150,7 +150,7 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
             self.tail = left;
             self.allocator.clear_register(left, NEXT);
         }
-        self.allocator.remove_node(i as u32);
+        self.allocator.remove_node(i);
         self.sequence_number += 1;
         Some(value)
     }
@@ -214,8 +214,8 @@ impl<'a, T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Iter
     }
 }
 
-impl<'a, T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> DoubleEndedIterator
-    for DequeIterator<'a, T, MAX_SIZE>
+impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> DoubleEndedIterator
+    for DequeIterator<'_, T, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.terminated {
@@ -273,8 +273,8 @@ impl<'a, T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Iter
     }
 }
 
-impl<'a, T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> DoubleEndedIterator
-    for DequeIteratorMut<'a, T, MAX_SIZE>
+impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> DoubleEndedIterator
+    for DequeIteratorMut<'_, T, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.terminated {
@@ -302,100 +302,107 @@ impl<'a, T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Doub
     }
 }
 
-#[test]
-/// This test covers the primary use cases of the deque
-fn test_deque() {
-    use rand::thread_rng;
-    use rand::Rng;
-    use std::collections::VecDeque;
-    let mut rng = thread_rng();
-    type Q = Deque<u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Q>()];
-    let mut v = VecDeque::new();
-    let q = Q::new_from_slice(buf.as_mut_slice());
-    (0..128).for_each(|_| {
-        let t = rng.gen::<u64>();
-        q.push_back(t);
-        v.push_back(t);
-    });
-    (0..128).for_each(|_| {
-        let t = rng.gen::<u64>();
-        q.push_front(t);
-        v.push_front(t);
-    });
-    for ((_, i), j) in q.iter().zip(v.iter()) {
-        assert_eq!(i, j);
-    }
-    for ((_, i), j) in q.iter().rev().zip(v.iter().rev()) {
-        assert_eq!(i, j);
-    }
+#[cfg(test)]
+mod test {
+    use alloc::vec;
 
-    {
-        let mut q_iter = q.iter();
-        let mut v_iter = v.iter();
-        let breakpoint = rng.gen_range(1, 255);
-        for _ in 0..breakpoint {
-            assert_eq!(q_iter.next().map(|x| x.1), v_iter.next());
+    use super::*;
+
+    #[test]
+    /// This test covers the primary use cases of the deque
+    fn test_deque() {
+        use alloc::collections::VecDeque;
+        use rand::thread_rng;
+        use rand::Rng;
+        let mut rng = thread_rng();
+        type Q = Deque<u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Q>()];
+        let mut v = VecDeque::new();
+        let q = Q::new_from_slice(buf.as_mut_slice());
+        (0..128).for_each(|_| {
+            let t = rng.gen::<u64>();
+            q.push_back(t);
+            v.push_back(t);
+        });
+        (0..128).for_each(|_| {
+            let t = rng.gen::<u64>();
+            q.push_front(t);
+            v.push_front(t);
+        });
+        for ((_, i), j) in q.iter().zip(v.iter()) {
+            assert_eq!(i, j);
         }
-        for _ in breakpoint..256 {
-            assert_eq!(q_iter.next_back().map(|x| x.1), v_iter.next_back());
+        for ((_, i), j) in q.iter().rev().zip(v.iter().rev()) {
+            assert_eq!(i, j);
         }
 
-        assert!(q_iter.next().is_none());
-        assert!(q_iter.next_back().is_none());
-        assert!(v_iter.next().is_none());
-        assert!(v_iter.next_back().is_none());
-        // Do it again for good measure
-        assert!(q_iter.next().is_none());
-        assert!(q_iter.next_back().is_none());
-        assert!(v_iter.next().is_none());
-        assert!(v_iter.next_back().is_none());
-    }
+        {
+            let mut q_iter = q.iter();
+            let mut v_iter = v.iter();
+            let breakpoint = rng.gen_range(1, 255);
+            for _ in 0..breakpoint {
+                assert_eq!(q_iter.next().map(|x| x.1), v_iter.next());
+            }
+            for _ in breakpoint..256 {
+                assert_eq!(q_iter.next_back().map(|x| x.1), v_iter.next_back());
+            }
 
-    {
-        let mut q_iter_mut = q.iter_mut();
-        let mut v_iter_mut = v.iter_mut();
-        let breakpoint = rng.gen_range(1, 255);
-        for _ in 0..breakpoint {
-            assert_eq!(q_iter_mut.next().map(|x| x.1), v_iter_mut.next());
+            assert!(q_iter.next().is_none());
+            assert!(q_iter.next_back().is_none());
+            assert!(v_iter.next().is_none());
+            assert!(v_iter.next_back().is_none());
+            // Do it again for good measure
+            assert!(q_iter.next().is_none());
+            assert!(q_iter.next_back().is_none());
+            assert!(v_iter.next().is_none());
+            assert!(v_iter.next_back().is_none());
         }
-        for _ in breakpoint..256 {
-            assert_eq!(q_iter_mut.next_back().map(|x| x.1), v_iter_mut.next_back());
+
+        {
+            let mut q_iter_mut = q.iter_mut();
+            let mut v_iter_mut = v.iter_mut();
+            let breakpoint = rng.gen_range(1, 255);
+            for _ in 0..breakpoint {
+                assert_eq!(q_iter_mut.next().map(|x| x.1), v_iter_mut.next());
+            }
+            for _ in breakpoint..256 {
+                assert_eq!(q_iter_mut.next_back().map(|x| x.1), v_iter_mut.next_back());
+            }
+
+            assert!(q_iter_mut.next().is_none());
+            assert!(q_iter_mut.next_back().is_none());
+            assert!(v_iter_mut.next().is_none());
+            assert!(v_iter_mut.next_back().is_none());
+            // Do it again for good measure
+            assert!(q_iter_mut.next().is_none());
+            assert!(q_iter_mut.next_back().is_none());
+            assert!(v_iter_mut.next().is_none());
+            assert!(v_iter_mut.next_back().is_none());
         }
 
-        assert!(q_iter_mut.next().is_none());
-        assert!(q_iter_mut.next_back().is_none());
-        assert!(v_iter_mut.next().is_none());
-        assert!(v_iter_mut.next_back().is_none());
-        // Do it again for good measure
-        assert!(q_iter_mut.next().is_none());
-        assert!(q_iter_mut.next_back().is_none());
-        assert!(v_iter_mut.next().is_none());
-        assert!(v_iter_mut.next_back().is_none());
+        (0..256).for_each(|_| {
+            assert_eq!(q.pop_back(), v.pop_back());
+        });
+        assert!(q.is_empty() && v.is_empty());
+        (0..128).for_each(|_| {
+            let t = rng.gen::<u64>();
+            q.push_back(t);
+            v.push_back(t);
+        });
+        (0..128).for_each(|_| {
+            let t = rng.gen::<u64>();
+            q.push_front(t);
+            v.push_front(t);
+        });
+        for ((_, i), j) in q.iter().zip(v.iter()) {
+            assert_eq!(i, j);
+        }
+        for ((_, i), j) in q.iter().rev().zip(v.iter().rev()) {
+            assert_eq!(i, j);
+        }
+        (0..256).for_each(|_| {
+            assert_eq!(q.pop_front(), v.pop_front());
+        });
+        assert!(q.is_empty() && v.is_empty());
     }
-
-    (0..256).for_each(|_| {
-        assert_eq!(q.pop_back(), v.pop_back());
-    });
-    assert!(q.is_empty() && v.is_empty());
-    (0..128).for_each(|_| {
-        let t = rng.gen::<u64>();
-        q.push_back(t);
-        v.push_back(t);
-    });
-    (0..128).for_each(|_| {
-        let t = rng.gen::<u64>();
-        q.push_front(t);
-        v.push_front(t);
-    });
-    for ((_, i), j) in q.iter().zip(v.iter()) {
-        assert_eq!(i, j);
-    }
-    for ((_, i), j) in q.iter().rev().zip(v.iter().rev()) {
-        assert_eq!(i, j);
-    }
-    (0..256).for_each(|_| {
-        assert_eq!(q.pop_front(), v.pop_front());
-    });
-    assert!(q.is_empty() && v.is_empty());
 }

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -63,30 +63,30 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
         self.allocator.initialize();
     }
 
-    pub fn front(&self) -> Option<&T> {
+    pub const fn front(&self) -> Option<&T> {
         if self.head == SENTINEL {
             return None;
         }
         Some(self.get_node(self.head))
     }
 
-    pub fn back(&self) -> Option<&T> {
+    pub const fn back(&self) -> Option<&T> {
         if self.tail == SENTINEL {
             return None;
         }
         Some(self.allocator.get(self.tail).get_value())
     }
 
-    pub fn get_next(&self, index: u32) -> u32 {
+    pub const fn get_next(&self, index: u32) -> u32 {
         self.allocator.get_register(index, NEXT)
     }
 
-    pub fn get_prev(&self, index: u32) -> u32 {
+    pub const fn get_prev(&self, index: u32) -> u32 {
         self.allocator.get_register(index, PREV)
     }
 
     #[inline(always)]
-    fn get_node(&self, i: u32) -> &T {
+    const fn get_node(&self, i: u32) -> &T {
         self.allocator.get(i).get_value()
     }
 
@@ -114,7 +114,7 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
         self.sequence_number += 1;
     }
 
-    pub fn pop_front(&mut self) -> Option<T> {
+    pub const fn pop_front(&mut self) -> Option<T> {
         if self.head == SENTINEL {
             return None;
         }
@@ -122,7 +122,7 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
         self._remove(head)
     }
 
-    pub fn pop_back(&mut self) -> Option<T> {
+    pub const fn pop_back(&mut self) -> Option<T> {
         if self.tail == SENTINEL {
             return None;
         }
@@ -130,7 +130,7 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
         self._remove(tail)
     }
 
-    fn _remove(&mut self, i: u32) -> Option<T> {
+    const fn _remove(&mut self, i: u32) -> Option<T> {
         let (left, right, value) = {
             let value = *self.get_node(i);
             let left = self.get_prev(i);
@@ -155,15 +155,15 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
         Some(value)
     }
 
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.allocator.size as usize
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    pub fn iter(&self) -> DequeIterator<'_, T, MAX_SIZE> {
+    pub const fn iter(&self) -> DequeIterator<'_, T, MAX_SIZE> {
         DequeIterator::<T, MAX_SIZE> {
             deque: self,
             fwd_ptr: self.head,
@@ -172,7 +172,7 @@ impl<T: Default + Copy + Clone + Pod + Zeroable, const MAX_SIZE: usize> Deque<T,
         }
     }
 
-    pub fn iter_mut(&mut self) -> DequeIteratorMut<'_, T, MAX_SIZE> {
+    pub const fn iter_mut(&mut self) -> DequeIteratorMut<'_, T, MAX_SIZE> {
         let head = self.head;
         let tail = self.tail;
         DequeIteratorMut::<T, MAX_SIZE> {

--- a/src/hash_table.rs
+++ b/src/hash_table.rs
@@ -114,7 +114,6 @@ impl<
 
     fn contains(&self, key: &K) -> bool {
         self._contains(key)
-        // self.get(key).is_some()
     }
 
     fn get(&self, key: &K) -> Option<&V> {

--- a/src/hash_table.rs
+++ b/src/hash_table.rs
@@ -7,7 +7,7 @@ use core::{
     hash::{BuildHasher, Hash},
     ops::{Index, IndexMut},
 };
-use hashbrown::DefaultHashBuilder;
+use foldhash::fast::FixedState;
 
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
@@ -37,7 +37,7 @@ impl<
         V: Default + Copy + Clone + Pod + Zeroable,
     > HashNode<K, V>
 {
-    pub fn new(key: K, value: V) -> Self {
+    pub const fn new(key: K, value: V) -> Self {
         Self { key, value }
     }
 }
@@ -62,14 +62,6 @@ unsafe impl<
     > Zeroable for HashTable<K, V, NUM_BUCKETS, MAX_SIZE>
 {
 }
-unsafe impl<
-        K: Hash + PartialEq + Copy + Clone + Default + Pod + Zeroable,
-        V: Default + Copy + Clone + Pod + Zeroable,
-        const NUM_BUCKETS: usize,
-        const MAX_SIZE: usize,
-    > Pod for HashTable<K, V, NUM_BUCKETS, MAX_SIZE>
-{
-}
 
 impl<
         K: Hash + PartialEq + Copy + Clone + Default + Pod + Zeroable,
@@ -77,6 +69,15 @@ impl<
         const NUM_BUCKETS: usize,
         const MAX_SIZE: usize,
     > ZeroCopy for HashTable<K, V, NUM_BUCKETS, MAX_SIZE>
+{
+}
+
+unsafe impl<
+        K: Hash + PartialEq + Copy + Clone + Default + Pod + Zeroable,
+        V: Default + Copy + Clone + Pod + Zeroable,
+        const NUM_BUCKETS: usize,
+        const MAX_SIZE: usize,
+    > Pod for HashTable<K, V, NUM_BUCKETS, MAX_SIZE>
 {
 }
 
@@ -112,11 +113,12 @@ impl<
     }
 
     fn contains(&self, key: &K) -> bool {
-        self.get(key).is_some()
+        self._contains(key)
+        // self.get(key).is_some()
     }
 
     fn get(&self, key: &K) -> Option<&V> {
-        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
+        let bucket_index = FixedState::default().hash_one(key) as usize % NUM_BUCKETS;
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
@@ -130,7 +132,7 @@ impl<
     }
 
     fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
+        let bucket_index = FixedState::default().hash_one(key) as usize % NUM_BUCKETS;
         let head = self.buckets[bucket_index];
         let mut curr_node = head;
         while curr_node != SENTINEL {
@@ -208,7 +210,7 @@ impl<
     > HashTable<K, V, NUM_BUCKETS, MAX_SIZE>
 {
     fn assert_proper_alignment() {
-        assert!(NUM_BUCKETS % 2 == 0);
+        assert!(NUM_BUCKETS.is_multiple_of(2));
     }
 
     pub fn initialize(&mut self) {
@@ -219,24 +221,24 @@ impl<
         Self::default()
     }
 
-    pub fn get_next(&self, index: u32) -> u32 {
+    pub const fn get_next(&self, index: u32) -> u32 {
         self.allocator.get_register(index, NodeField::Right as u32)
     }
 
-    pub fn get_prev(&self, index: u32) -> u32 {
+    pub const fn get_prev(&self, index: u32) -> u32 {
         self.allocator.get_register(index, NodeField::Left as u32)
     }
 
-    pub fn get_node(&self, index: u32) -> &HashNode<K, V> {
+    pub const fn get_node(&self, index: u32) -> &HashNode<K, V> {
         self.allocator.get(index).get_value()
     }
 
-    pub fn get_node_mut(&mut self, index: u32) -> &mut HashNode<K, V> {
+    pub const fn get_node_mut(&mut self, index: u32) -> &mut HashNode<K, V> {
         self.allocator.get_mut(index).get_value_mut()
     }
 
     fn _insert(&mut self, key: K, value: V) -> Option<u32> {
-        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
+        let bucket_index = FixedState::default().hash_one(key) as usize % NUM_BUCKETS;
         let head = self.buckets[bucket_index];
         let mut curr_node = head;
         while curr_node != SENTINEL {
@@ -265,9 +267,9 @@ impl<
     }
 
     pub fn _remove(&mut self, key: &K) -> Option<V> {
-        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
+        let bucket_index = FixedState::default().hash_one(key) as usize % NUM_BUCKETS;
         let head = self.buckets[bucket_index];
-        let mut curr_node = self.buckets[bucket_index];
+        let mut curr_node = head;
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
             if node.key == *key {
@@ -293,8 +295,8 @@ impl<
         None
     }
 
-    pub fn contains(&self, key: &K) -> bool {
-        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
+    pub fn _contains(&self, key: &K) -> bool {
+        let bucket_index = FixedState::default().hash_one(key) as usize % NUM_BUCKETS;
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
@@ -308,7 +310,7 @@ impl<
     }
 
     pub fn get_addr(&self, key: &K) -> u32 {
-        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
+        let bucket_index = FixedState::default().hash_one(key) as usize % NUM_BUCKETS;
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
@@ -321,7 +323,7 @@ impl<
         SENTINEL
     }
 
-    fn _iter(&self) -> HashTableIterator<'_, K, V, NUM_BUCKETS, MAX_SIZE> {
+    const fn _iter(&self) -> HashTableIterator<'_, K, V, NUM_BUCKETS, MAX_SIZE> {
         HashTableIterator::<K, V, NUM_BUCKETS, MAX_SIZE> {
             ht: self,
             bucket: 0,
@@ -329,7 +331,7 @@ impl<
         }
     }
 
-    fn _iter_mut(&mut self) -> HashTableIteratorMut<'_, K, V, NUM_BUCKETS, MAX_SIZE> {
+    const fn _iter_mut(&mut self) -> HashTableIteratorMut<'_, K, V, NUM_BUCKETS, MAX_SIZE> {
         let node = self.buckets[0];
         HashTableIteratorMut::<K, V, NUM_BUCKETS, MAX_SIZE> {
             ht: self,

--- a/src/hash_table.rs
+++ b/src/hash_table.rs
@@ -1,13 +1,13 @@
 use crate::node_allocator::{
     FromSlice, NodeAllocator, NodeAllocatorMap, NodeField, ZeroCopy, SENTINEL,
 };
+use alloc::boxed::Box;
 use bytemuck::{Pod, Zeroable};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hasher;
-use std::{
-    hash::Hash,
+use core::{
+    hash::{BuildHasher, Hash},
     ops::{Index, IndexMut},
 };
+use hashbrown::DefaultHashBuilder;
 
 #[repr(C)]
 #[derive(Default, Copy, Clone)]
@@ -116,9 +116,7 @@ impl<
     }
 
     fn get(&self, key: &K) -> Option<&V> {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let bucket_index = hasher.finish() as usize % NUM_BUCKETS;
+        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
@@ -132,9 +130,7 @@ impl<
     }
 
     fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let bucket_index = hasher.finish() as usize % NUM_BUCKETS;
+        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
         let head = self.buckets[bucket_index];
         let mut curr_node = head;
         while curr_node != SENTINEL {
@@ -240,9 +236,7 @@ impl<
     }
 
     fn _insert(&mut self, key: K, value: V) -> Option<u32> {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let bucket_index = hasher.finish() as usize % NUM_BUCKETS;
+        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
         let head = self.buckets[bucket_index];
         let mut curr_node = head;
         while curr_node != SENTINEL {
@@ -271,9 +265,7 @@ impl<
     }
 
     pub fn _remove(&mut self, key: &K) -> Option<V> {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let bucket_index = hasher.finish() as usize % NUM_BUCKETS;
+        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
         let head = self.buckets[bucket_index];
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
@@ -302,9 +294,7 @@ impl<
     }
 
     pub fn contains(&self, key: &K) -> bool {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let bucket_index = hasher.finish() as usize % NUM_BUCKETS;
+        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
@@ -318,9 +308,7 @@ impl<
     }
 
     pub fn get_addr(&self, key: &K) -> u32 {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let bucket_index = hasher.finish() as usize % NUM_BUCKETS;
+        let bucket_index = DefaultHashBuilder::default().hash_one(key) as usize % NUM_BUCKETS;
         let mut curr_node = self.buckets[bucket_index];
         while curr_node != SENTINEL {
             let node = self.get_node(curr_node);
@@ -425,12 +413,11 @@ impl<
 }
 
 impl<
-        'a,
         K: Hash + PartialEq + Copy + Clone + Default + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
         const NUM_BUCKETS: usize,
         const MAX_SIZE: usize,
-    > DoubleEndedIterator for HashTableIterator<'a, K, V, NUM_BUCKETS, MAX_SIZE>
+    > DoubleEndedIterator for HashTableIterator<'_, K, V, NUM_BUCKETS, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         None
@@ -484,12 +471,11 @@ impl<
 }
 
 impl<
-        'a,
         K: Hash + PartialEq + Copy + Clone + Default + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
         const NUM_BUCKETS: usize,
         const MAX_SIZE: usize,
-    > DoubleEndedIterator for HashTableIteratorMut<'a, K, V, NUM_BUCKETS, MAX_SIZE>
+    > DoubleEndedIterator for HashTableIteratorMut<'_, K, V, NUM_BUCKETS, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+extern crate alloc;
+
 pub mod avl_tree;
 pub mod critbit;
 pub mod deque;

--- a/src/node_allocator.rs
+++ b/src/node_allocator.rs
@@ -1,6 +1,7 @@
+use alloc::boxed::Box;
 use bytemuck::{Pod, Zeroable};
+use core::mem::{align_of, size_of};
 use num_derive::FromPrimitive;
-use std::mem::{align_of, size_of};
 
 /// Enum representing the fields of a tree node:
 /// 0 - left pointer
@@ -58,12 +59,12 @@ pub trait OrderedNodeAllocatorMap<K, V>: NodeAllocatorMap<K, V> {
 
 pub trait ZeroCopy: Pod {
     fn load_mut_bytes(data: &'_ mut [u8]) -> Option<&'_ mut Self> {
-        let size = std::mem::size_of::<Self>();
+        let size = core::mem::size_of::<Self>();
         bytemuck::try_from_bytes_mut(&mut data[..size]).ok()
     }
 
     fn load_bytes(data: &'_ [u8]) -> Option<&'_ Self> {
-        let size = std::mem::size_of::<Self>();
+        let size = core::mem::size_of::<Self>();
         bytemuck::try_from_bytes(&data[..size]).ok()
     }
 }
@@ -207,14 +208,14 @@ impl<
     #[inline(always)]
     fn assert_proper_alignemnt(&self) {
         let reg_size = size_of::<u32>() * NUM_REGISTERS;
-        let self_ptr = std::slice::from_ref(self).as_ptr() as usize;
-        let node_ptr = std::slice::from_ref(&self.nodes).as_ptr() as usize;
+        let self_ptr = alloc::slice::from_ref(self).as_ptr() as usize;
+        let node_ptr = alloc::slice::from_ref(&self.nodes).as_ptr() as usize;
         let self_align = align_of::<Self>();
         let t_index = node_ptr + reg_size;
         let t_align = align_of::<T>();
         let t_size = size_of::<T>();
         assert!(
-            self_ptr % self_align as usize == 0,
+            self_ptr % self_align == 0,
             "NodeAllocator alignment mismatch, address is {} which is not a multiple of the struct alignment ({})",
             self_ptr,
             self_align,

--- a/src/node_allocator.rs
+++ b/src/node_allocator.rs
@@ -96,37 +96,37 @@ impl<T: Copy + Clone + Pod + Zeroable + Default, const NUM_REGISTERS: usize>
     Node<T, NUM_REGISTERS>
 {
     #[inline(always)]
-    pub(crate) fn get_free_list_register(&self) -> u32 {
+    pub(crate) const fn get_free_list_register(&self) -> u32 {
         self.registers[0]
     }
 
     #[inline(always)]
-    pub fn get_register(&self, r: usize) -> u32 {
+    pub const fn get_register(&self, r: usize) -> u32 {
         self.registers[r]
     }
 
     #[inline(always)]
-    pub(crate) fn set_free_list_register(&mut self, v: u32) {
+    pub(crate) const fn set_free_list_register(&mut self, v: u32) {
         self.registers[0] = v;
     }
 
     #[inline(always)]
-    pub fn set_register(&mut self, r: usize, v: u32) {
+    pub const fn set_register(&mut self, r: usize, v: u32) {
         self.registers[r] = v;
     }
 
     #[inline(always)]
-    pub fn set_value(&mut self, v: T) {
+    pub const fn set_value(&mut self, v: T) {
         self.value = v;
     }
 
     #[inline(always)]
-    pub fn get_value_mut(&mut self) -> &mut T {
+    pub const fn get_value_mut(&mut self) -> &mut T {
         &mut self.value
     }
 
     #[inline(always)]
-    pub fn get_value(&self) -> &T {
+    pub const fn get_value(&self) -> &T {
         &self.value
     }
 }
@@ -215,13 +215,13 @@ impl<
         let t_align = align_of::<T>();
         let t_size = size_of::<T>();
         assert!(
-            self_ptr % self_align == 0,
+            self_ptr.is_multiple_of(self_align),
             "NodeAllocator alignment mismatch, address is {} which is not a multiple of the struct alignment ({})",
             self_ptr,
             self_align,
         );
         assert!(
-            t_size % t_align == 0,
+            t_size.is_multiple_of(t_align),
             "Size of T ({}) is not a multiple of the alignment of T ({})",
             t_size,
             t_align,
@@ -233,9 +233,12 @@ impl<
             self_align,
         );
         assert!(node_ptr == self_ptr + 16, "Nodes are misaligned");
-        assert!(t_index % t_align == 0, "First index of T is misaligned");
         assert!(
-            (t_index + t_size + reg_size) % t_align == 0,
+            t_index.is_multiple_of(t_align),
+            "First index of T is misaligned"
+        );
+        assert!(
+            (t_index + t_size + reg_size).is_multiple_of(t_align),
             "Subsequent indices of T are misaligned"
         );
     }
@@ -252,12 +255,12 @@ impl<
     }
 
     #[inline(always)]
-    pub fn get(&self, i: u32) -> &Node<T, NUM_REGISTERS> {
+    pub const fn get(&self, i: u32) -> &Node<T, NUM_REGISTERS> {
         &self.nodes[(i - 1) as usize]
     }
 
     #[inline(always)]
-    pub fn get_mut(&mut self, i: u32) -> &mut Node<T, NUM_REGISTERS> {
+    pub const fn get_mut(&mut self, i: u32) -> &mut Node<T, NUM_REGISTERS> {
         &mut self.nodes[(i - 1) as usize]
     }
 
@@ -282,7 +285,7 @@ impl<
 
     /// Removes the node at index `i` from the allocator and adds the index to the free list
     /// When deleting nodes, you MUST clear all registers prior to calling `remove_node`
-    pub fn remove_node(&mut self, i: u32) -> Option<&T> {
+    pub const fn remove_node(&mut self, i: u32) -> Option<&T> {
         if i == SENTINEL {
             return None;
         }
@@ -294,7 +297,7 @@ impl<
     }
 
     #[inline(always)]
-    pub fn disconnect(&mut self, i: u32, j: u32, r_i: u32, r_j: u32) {
+    pub const fn disconnect(&mut self, i: u32, j: u32, r_i: u32, r_j: u32) {
         if i != SENTINEL {
             // assert!(j == self.get_register(i, r_i), "Nodes are not connected");
             self.clear_register(i, r_i);
@@ -306,14 +309,14 @@ impl<
     }
 
     #[inline(always)]
-    pub fn clear_register(&mut self, i: u32, r_i: u32) {
+    pub const fn clear_register(&mut self, i: u32, r_i: u32) {
         if i != SENTINEL {
             self.get_mut(i).set_register(r_i as usize, SENTINEL);
         }
     }
 
     #[inline(always)]
-    pub fn connect(&mut self, i: u32, j: u32, r_i: u32, r_j: u32) {
+    pub const fn connect(&mut self, i: u32, j: u32, r_i: u32, r_j: u32) {
         if i != SENTINEL {
             self.get_mut(i).set_register(r_i as usize, j);
         }
@@ -323,14 +326,14 @@ impl<
     }
 
     #[inline(always)]
-    pub fn set_register(&mut self, i: u32, value: u32, r_i: u32) {
+    pub const fn set_register(&mut self, i: u32, value: u32, r_i: u32) {
         if i != SENTINEL {
             self.get_mut(i).set_register(r_i as usize, value);
         }
     }
 
     #[inline(always)]
-    pub fn get_register(&self, i: u32, r_i: u32) -> u32 {
+    pub const fn get_register(&self, i: u32, r_i: u32) -> u32 {
         if i != SENTINEL {
             self.get(i).get_register(r_i as usize)
         } else {

--- a/src/red_black_tree.rs
+++ b/src/red_black_tree.rs
@@ -33,7 +33,7 @@ pub enum Color {
 
 /// Exploits the fact that LEFT and RIGHT are set to 0 and 1 respectively
 #[inline(always)]
-fn opposite(dir: u32) -> u32 {
+const fn opposite(dir: u32) -> u32 {
     1 - dir
 }
 
@@ -65,7 +65,7 @@ impl<
         V: Default + Copy + Clone + Pod + Zeroable,
     > RBNode<K, V>
 {
-    pub fn new(key: K, value: V) -> Self {
+    pub const fn new(key: K, value: V) -> Self {
         Self { key, value }
     }
 }
@@ -271,9 +271,10 @@ impl<
 
     fn assert_proper_alignment() {
         // TODO is this a sufficient coverage of the edge cases?
-        assert!(core::mem::size_of::<V>() % core::mem::align_of::<K>() == 0);
-        assert!(core::mem::size_of::<RBNode<K, V>>() % core::mem::align_of::<RBNode<K, V>>() == 0);
-        assert!(core::mem::size_of::<RBNode<K, V>>() % 8_usize == 0);
+        assert!(core::mem::size_of::<V>().is_multiple_of(core::mem::align_of::<K>()));
+        assert!(core::mem::size_of::<RBNode<K, V>>()
+            .is_multiple_of(core::mem::align_of::<RBNode<K, V>>()));
+        assert!(core::mem::size_of::<RBNode<K, V>>().is_multiple_of(8_usize));
     }
 
     pub fn is_valid_red_black_tree(&self) -> bool {
@@ -327,58 +328,58 @@ impl<
         self.allocator.initialize();
     }
 
-    pub fn get_node(&self, node: u32) -> &RBNode<K, V> {
+    pub const fn get_node(&self, node: u32) -> &RBNode<K, V> {
         self.allocator.get(node).get_value()
     }
 
-    pub fn get_node_mut(&mut self, node: u32) -> &mut RBNode<K, V> {
+    pub const fn get_node_mut(&mut self, node: u32) -> &mut RBNode<K, V> {
         self.allocator.get_mut(node).get_value_mut()
     }
 
     #[inline(always)]
-    fn _color_red(&mut self, node: u32) {
+    const fn _color_red(&mut self, node: u32) {
         if node != SENTINEL {
             self.allocator.set_register(node, Color::Red as u32, COLOR);
         }
     }
 
     #[inline(always)]
-    fn _color_black(&mut self, node: u32) {
+    const fn _color_black(&mut self, node: u32) {
         self.allocator
             .set_register(node, Color::Black as u32, COLOR);
     }
 
     #[inline(always)]
-    fn _color_node(&mut self, node: u32, color: u32) {
+    const fn _color_node(&mut self, node: u32, color: u32) {
         self.allocator.set_register(node, color, COLOR);
     }
 
     #[inline(always)]
-    pub fn is_red(&self, node: u32) -> bool {
+    pub const fn is_red(&self, node: u32) -> bool {
         self.allocator.get_register(node, COLOR) == Color::Red as u32
     }
 
     #[inline(always)]
-    pub fn is_black(&self, node: u32) -> bool {
+    pub const fn is_black(&self, node: u32) -> bool {
         self.allocator.get_register(node, COLOR) == Color::Black as u32
     }
 
     #[inline(always)]
-    pub fn get_child(&self, node: u32, dir: u32) -> u32 {
+    pub const fn get_child(&self, node: u32, dir: u32) -> u32 {
         self.allocator.get_register(node, dir)
     }
 
     #[inline(always)]
-    pub fn is_leaf(&self, node: u32) -> bool {
+    pub const fn is_leaf(&self, node: u32) -> bool {
         self.get_left(node) == SENTINEL && self.get_right(node) == SENTINEL
     }
 
     #[inline(always)]
-    pub fn is_root(&self, node: u32) -> bool {
+    pub const fn is_root(&self, node: u32) -> bool {
         self.root == node
     }
 
-    pub fn get_dir(&self, node: u32, dir: u32) -> u32 {
+    pub const fn get_dir(&self, node: u32, dir: u32) -> u32 {
         if dir == Field::Left as u32 {
             self.get_left(node)
         } else {
@@ -387,22 +388,22 @@ impl<
     }
 
     #[inline(always)]
-    pub fn get_left(&self, node: u32) -> u32 {
+    pub const fn get_left(&self, node: u32) -> u32 {
         self.allocator.get_register(node, Field::Left as u32)
     }
 
     #[inline(always)]
-    pub fn get_right(&self, node: u32) -> u32 {
+    pub const fn get_right(&self, node: u32) -> u32 {
         self.allocator.get_register(node, Field::Right as u32)
     }
 
     #[inline(always)]
-    pub fn get_color(&self, node: u32) -> u32 {
+    pub const fn get_color(&self, node: u32) -> u32 {
         self.allocator.get_register(node, COLOR)
     }
 
     #[inline(always)]
-    pub fn get_parent(&self, node: u32) -> u32 {
+    pub const fn get_parent(&self, node: u32) -> u32 {
         self.allocator.get_register(node, Field::Parent as u32)
     }
 
@@ -418,7 +419,7 @@ impl<
         }
     }
 
-    fn _remove_allocator_node(&mut self, node: u32) {
+    const fn _remove_allocator_node(&mut self, node: u32) {
         // Clear all registers
         self.allocator.clear_register(node, Field::Parent as u32);
         self.allocator.clear_register(node, COLOR);
@@ -429,7 +430,7 @@ impl<
     }
 
     #[inline(always)]
-    fn _connect(&mut self, parent: u32, child: u32, dir: u32) {
+    const fn _connect(&mut self, parent: u32, child: u32, dir: u32) {
         self.allocator
             .connect(parent, child, dir, Field::Parent as u32);
     }
@@ -638,7 +639,7 @@ impl<
     }
 
     fn _fix_remove(&mut self, mut node_index: u32, parent_and_dir: Option<(u32, u32)>) {
-        let (mut parent, mut dir) = parent_and_dir.unwrap_or({
+        let (mut parent, mut dir) = parent_and_dir.unwrap_or_else(|| {
             let parent = self.get_parent(node_index);
             let dir = self._child_dir(parent, node_index);
             (parent, dir)
@@ -710,7 +711,7 @@ impl<
         }
     }
 
-    fn _find_min(&self, index: u32) -> u32 {
+    const fn _find_min(&self, index: u32) -> u32 {
         let mut node = index;
         while self.get_left(node) != SENTINEL {
             node = self.get_left(node);
@@ -718,7 +719,7 @@ impl<
         node
     }
 
-    fn _find_max(&self, index: u32) -> u32 {
+    const fn _find_max(&self, index: u32) -> u32 {
         let mut node = index;
         while self.get_right(node) != SENTINEL {
             node = self.get_right(node);
@@ -726,7 +727,7 @@ impl<
         node
     }
 
-    fn _iter(&self) -> RedBlackTreeIterator<'_, K, V, MAX_SIZE> {
+    const fn _iter(&self) -> RedBlackTreeIterator<'_, K, V, MAX_SIZE> {
         RedBlackTreeIterator::<K, V, MAX_SIZE> {
             tree: self,
             fwd_stack: vec![],
@@ -739,7 +740,7 @@ impl<
         }
     }
 
-    fn _iter_mut(&mut self) -> RedBlackTreeIteratorMut<'_, K, V, MAX_SIZE> {
+    const fn _iter_mut(&mut self) -> RedBlackTreeIteratorMut<'_, K, V, MAX_SIZE> {
         let node = self.root;
         RedBlackTreeIteratorMut::<K, V, MAX_SIZE> {
             tree: self,
@@ -987,11 +988,13 @@ mod test {
         type Rbt = RedBlackTree<u64, u64, 1024>;
         let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
         let tree = Rbt::new_from_slice(buf.as_mut_slice());
-        let addrs = [tree.insert(61, 0).unwrap(),
+        let addrs = [
+            tree.insert(61, 0).unwrap(),
             tree.insert(52, 0).unwrap(),
             tree.insert(85, 0).unwrap(),
             tree.insert(76, 0).unwrap(),
-            tree.insert(93, 0).unwrap()];
+            tree.insert(93, 0).unwrap(),
+        ];
 
         let parent = addrs[4];
         let uncle = addrs[3];
@@ -1034,10 +1037,12 @@ mod test {
         type Rbt = RedBlackTree<u64, u64, 1024>;
         let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
         let tree = Rbt::new_from_slice(buf.as_mut_slice());
-        let addrs = [tree.insert(61, 0).unwrap(),
+        let addrs = [
+            tree.insert(61, 0).unwrap(),
             tree.insert(52, 0).unwrap(),
             tree.insert(85, 0).unwrap(),
-            tree.insert(93, 0).unwrap()];
+            tree.insert(93, 0).unwrap(),
+        ];
 
         let parent = addrs[3];
         // Uncle is black as it is null
@@ -1085,10 +1090,12 @@ mod test {
         type Rbt = RedBlackTree<u64, u64, 1024>;
         let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
         let tree = Rbt::new_from_slice(buf.as_mut_slice());
-        let addrs = [tree.insert(61, 0).unwrap(),
+        let addrs = [
+            tree.insert(61, 0).unwrap(),
             tree.insert(52, 0).unwrap(),
             tree.insert(85, 0).unwrap(),
-            tree.insert(93, 0).unwrap()];
+            tree.insert(93, 0).unwrap(),
+        ];
 
         let parent = addrs[3];
         // Uncle is black as it is null
@@ -1136,10 +1143,12 @@ mod test {
         type Rbt = RedBlackTree<u64, u64, 1024>;
         let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
         let tree = Rbt::new_from_slice(buf.as_mut_slice());
-        let addrs = [tree.insert(61, 0).unwrap(),
+        let addrs = [
+            tree.insert(61, 0).unwrap(),
             tree.insert(85, 0).unwrap(),
             tree.insert(52, 0).unwrap(),
-            tree.insert(41, 0).unwrap()];
+            tree.insert(41, 0).unwrap(),
+        ];
 
         let parent = addrs[3];
         // Uncle is black as it is null
@@ -1187,10 +1196,12 @@ mod test {
         type Rbt = RedBlackTree<u64, u64, 1024>;
         let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
         let tree = Rbt::new_from_slice(buf.as_mut_slice());
-        let addrs = [tree.insert(61, 0).unwrap(),
+        let addrs = [
+            tree.insert(61, 0).unwrap(),
             tree.insert(85, 0).unwrap(),
             tree.insert(52, 0).unwrap(),
-            tree.insert(41, 0).unwrap()];
+            tree.insert(41, 0).unwrap(),
+        ];
 
         let parent = addrs[3];
         // Uncle is black as it is null

--- a/src/red_black_tree.rs
+++ b/src/red_black_tree.rs
@@ -1,12 +1,19 @@
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use bytemuck::{Pod, Zeroable};
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
-use std::{
+use core::{
     cmp::Ordering,
     fmt::Debug,
     ops::{Index, IndexMut},
-    vec,
 };
+use libc_print::std_name::println;
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
 
 use crate::node_allocator::{
     FromSlice, NodeAllocator, NodeAllocatorMap, OrderedNodeAllocatorMap, TreeField as Field,
@@ -233,8 +240,7 @@ impl<
         let mut s = String::new();
         let mut stack = vec![(self.root, "".to_string(), "".to_string())];
 
-        while !stack.is_empty() {
-            let (node, mut padding, pointer) = stack.pop().unwrap();
+        while let Some((node, mut padding, pointer)) = stack.pop() {
             if node == SENTINEL {
                 continue;
             }
@@ -265,9 +271,9 @@ impl<
 
     fn assert_proper_alignment() {
         // TODO is this a sufficient coverage of the edge cases?
-        assert!(std::mem::size_of::<V>() % std::mem::align_of::<K>() == 0);
-        assert!(std::mem::size_of::<RBNode<K, V>>() % std::mem::align_of::<RBNode<K, V>>() == 0);
-        assert!(std::mem::size_of::<RBNode<K, V>>() % 8_usize == 0);
+        assert!(core::mem::size_of::<V>() % core::mem::align_of::<K>() == 0);
+        assert!(core::mem::size_of::<RBNode<K, V>>() % core::mem::align_of::<RBNode<K, V>>() == 0);
+        assert!(core::mem::size_of::<RBNode<K, V>>() % 8_usize == 0);
     }
 
     pub fn is_valid_red_black_tree(&self) -> bool {
@@ -283,8 +289,7 @@ impl<
         let mut stack = vec![(self.root, 0)];
         let mut black_count = vec![];
 
-        while !stack.is_empty() {
-            let (node_index, mut count) = stack.pop().unwrap();
+        while let Some((node_index, mut count)) = stack.pop() {
             count += self.is_black(node_index) as u32;
             if self.is_leaf(node_index) {
                 black_count.push(count);
@@ -308,7 +313,7 @@ impl<
         // All paths from root to leaf must have the same number of black nodes
         let balanced = black_count.iter().all(|&x| x == black_count[0]);
         if !balanced {
-            println!("Invalid Red-Black Tree: All paths must have the same number of black nodes",);
+            println!("Invalid Red-Black Tree: All paths must have the same number of black nodes");
         }
         balanced
     }
@@ -407,7 +412,7 @@ impl<
             None
         } else {
             // Otherwise copy out and remove tree node
-            let root_node = self.get_node(self.root).clone();
+            let root_node = *self.get_node(self.root);
             self._remove_tree_node(self.root);
             Some(root_node)
         }
@@ -534,12 +539,12 @@ impl<
                 self._rotate_dir(grandparent, opposite(dir));
             }
         }
-        self._color_black(self.root as u32);
+        self._color_black(self.root);
         Some(())
     }
 
     fn _remove(&mut self, key: &K) -> Option<V> {
-        let mut curr_node_index = self.root as u32;
+        let mut curr_node_index = self.root;
         if curr_node_index == SENTINEL {
             return None;
         }
@@ -660,7 +665,7 @@ impl<
                 self._color_black(parent);
                 self._color_black(self.get_dir(sibling, opposite(dir)));
                 self._rotate_dir(parent, dir);
-                node_index = self.root as u32;
+                node_index = self.root;
             }
             if self.is_root(node_index) || self.is_red(node_index) {
                 break;
@@ -824,11 +829,10 @@ impl<
 }
 
 impl<
-        'a,
         K: Debug + PartialOrd + Ord + Copy + Clone + Default + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
         const MAX_SIZE: usize,
-    > DoubleEndedIterator for RedBlackTreeIterator<'a, K, V, MAX_SIZE>
+    > DoubleEndedIterator for RedBlackTreeIterator<'_, K, V, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while !self.terminated && (!self.rev_stack.is_empty() || self.rev_ptr != SENTINEL) {
@@ -908,11 +912,10 @@ impl<
 }
 
 impl<
-        'a,
         K: Debug + PartialOrd + Ord + Copy + Clone + Default + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
         const MAX_SIZE: usize,
-    > DoubleEndedIterator for RedBlackTreeIteratorMut<'a, K, V, MAX_SIZE>
+    > DoubleEndedIterator for RedBlackTreeIteratorMut<'_, K, V, MAX_SIZE>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while !self.terminated && (!self.rev_stack.is_empty() || self.rev_ptr != SENTINEL) {
@@ -969,417 +972,406 @@ impl<
     }
 }
 
-#[test]
-/// This test addresses the case where a node's parent and uncle are both red.
-/// This is resolved by coloring the parent and uncle black and the grandparent red.
-fn test_insert_with_red_parent_and_uncle() {
-    type Rbt = RedBlackTree<u64, u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let addrs = vec![
-        tree.insert(61, 0).unwrap(),
-        tree.insert(52, 0).unwrap(),
-        tree.insert(85, 0).unwrap(),
-        tree.insert(76, 0).unwrap(),
-        tree.insert(93, 0).unwrap(),
-    ];
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate std;
 
-    let parent = addrs[4];
-    let uncle = addrs[3];
-    let grandparent = addrs[2];
-
-    assert_eq!(tree.get_left(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_right(addrs[0]), grandparent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(grandparent), addrs[0]);
-
-    assert_eq!(tree.get_left(grandparent), uncle);
-    assert_eq!(tree.get_right(grandparent), parent);
-    assert_eq!(tree.get_parent(uncle), grandparent);
-    assert_eq!(tree.get_parent(parent), grandparent);
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
-    assert!(tree.is_red(uncle) && tree.is_red(parent));
-
-    let leaf = tree.insert(100, 0).unwrap();
-
-    assert!(
-        tree.is_black(addrs[0])
-            && tree.is_black(addrs[1])
-            && tree.is_black(uncle)
-            && tree.is_black(parent)
-    );
-    assert!(tree.is_red(grandparent) && tree.is_red(leaf));
-}
-
-#[test]
-/// This test addresses the case where a node's parent (P) is red and uncle is black.
-/// The new leaf (L) is the right child of the parent and the parent is the right
-/// child of the grandparent (G).
-///
-/// "P is right child of G and L is right child of P."
-///
-/// We resolve this by rotating the grandparent left and then
-/// fixing the colors.
-fn test_right_insert_with_red_right_child_parent_and_black_uncle() {
-    type Rbt = RedBlackTree<u64, u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let addrs = vec![
-        tree.insert(61, 0).unwrap(),
-        tree.insert(52, 0).unwrap(),
-        tree.insert(85, 0).unwrap(),
-        tree.insert(93, 0).unwrap(),
-    ];
-
-    let parent = addrs[3];
-    // Uncle is black as it is null
-    let grandparent = addrs[2];
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
-    assert!(tree.is_red(parent));
-
-    assert_eq!(tree.get_left(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_right(addrs[0]), grandparent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(grandparent), addrs[0]);
-
-    assert_eq!(tree.get_left(grandparent), SENTINEL);
-    assert_eq!(tree.get_right(grandparent), parent);
-    assert_eq!(tree.get_parent(parent), grandparent);
-
-    let leaf = tree.insert(100, 0).unwrap();
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(parent));
-    assert!(tree.is_red(grandparent) && tree.is_red(leaf));
-
-    assert_eq!(tree.get_left(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_right(addrs[0]), parent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(parent), addrs[0]);
-
-    assert_eq!(tree.get_left(parent), grandparent);
-    assert_eq!(tree.get_right(parent), leaf);
-    assert_eq!(tree.get_parent(grandparent), parent);
-    assert_eq!(tree.get_parent(leaf), parent);
-    assert!(tree.is_leaf(leaf) && tree.is_leaf(grandparent));
-}
-
-#[test]
-/// This test addresses the case where a node's parent is red and uncle is black.
-/// The new leaf is the left child of the parent and the parent is the right
-/// child of the grandparent.
-///
-/// "P is right child of G and L is left child of P."
-///
-/// We resolve this by rotating the parent right then applying the same
-/// algorithm as the previous test.
-fn test_left_insert_with_red_right_child_parent_and_black_uncle() {
-    type Rbt = RedBlackTree<u64, u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let addrs = vec![
-        tree.insert(61, 0).unwrap(),
-        tree.insert(52, 0).unwrap(),
-        tree.insert(85, 0).unwrap(),
-        tree.insert(93, 0).unwrap(),
-    ];
-
-    let parent = addrs[3];
-    // Uncle is black as it is null
-    let grandparent = addrs[2];
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
-    assert!(tree.is_red(parent));
-
-    assert_eq!(tree.get_left(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_right(addrs[0]), grandparent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(grandparent), addrs[0]);
-
-    assert_eq!(tree.get_left(grandparent), SENTINEL);
-    assert_eq!(tree.get_right(grandparent), parent);
-    assert_eq!(tree.get_parent(parent), grandparent);
-
-    let leaf = tree.insert(87, 0).unwrap();
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(leaf));
-    assert!(tree.is_red(grandparent) && tree.is_red(parent));
-
-    assert_eq!(tree.get_left(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_right(addrs[0]), leaf);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(leaf), addrs[0]);
-
-    assert_eq!(tree.get_left(leaf), grandparent);
-    assert_eq!(tree.get_right(leaf), parent);
-    assert_eq!(tree.get_parent(grandparent), leaf);
-    assert_eq!(tree.get_parent(parent), leaf);
-    assert!(tree.is_leaf(parent) && tree.is_leaf(grandparent));
-}
-
-#[test]
-/// This test addresses the case where a node's parent is red and uncle is black.
-/// The new leaf is the left child of the parent and the parent is the left
-/// child of the grandparent.
-///
-/// "P is left child of G and L is left child of P."
-///
-/// We resolve this by rotating the grandparent right and then
-/// fixing the colors.
-fn test_left_insert_with_red_left_child_parent_and_black_uncle() {
-    type Rbt = RedBlackTree<u64, u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let addrs = vec![
-        tree.insert(61, 0).unwrap(),
-        tree.insert(85, 0).unwrap(),
-        tree.insert(52, 0).unwrap(),
-        tree.insert(41, 0).unwrap(),
-    ];
-
-    let parent = addrs[3];
-    // Uncle is black as it is null
-    let grandparent = addrs[2];
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
-    assert!(tree.is_red(parent));
-
-    assert_eq!(tree.get_right(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_left(addrs[0]), grandparent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(grandparent), addrs[0]);
-
-    assert_eq!(tree.get_right(grandparent), SENTINEL);
-    assert_eq!(tree.get_left(grandparent), parent);
-    assert_eq!(tree.get_parent(parent), grandparent);
-
-    let leaf = tree.insert(25, 0).unwrap();
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(parent));
-    assert!(tree.is_red(grandparent) && tree.is_red(leaf));
-
-    assert_eq!(tree.get_right(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_left(addrs[0]), parent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(parent), addrs[0]);
-
-    assert_eq!(tree.get_right(parent), grandparent);
-    assert_eq!(tree.get_left(parent), leaf);
-    assert_eq!(tree.get_parent(grandparent), parent);
-    assert_eq!(tree.get_parent(leaf), parent);
-    assert!(tree.is_leaf(leaf) && tree.is_leaf(grandparent));
-}
-
-#[test]
-/// This test addresses the case where a node's parent is red and uncle is black.
-/// The new leaf is the right child of the parent and the parent is the left
-/// child of the grandparent.
-///
-/// "P is left child of G and L is right child of P."
-///
-/// We resolve this by rotating the parent left then applying the same
-/// algorithm as the previous test.
-fn test_right_insert_with_red_left_child_parent_and_black_uncle() {
-    type Rbt = RedBlackTree<u64, u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let addrs = vec![
-        tree.insert(61, 0).unwrap(),
-        tree.insert(85, 0).unwrap(),
-        tree.insert(52, 0).unwrap(),
-        tree.insert(41, 0).unwrap(),
-    ];
-
-    let parent = addrs[3];
-    // Uncle is black as it is null
-    let grandparent = addrs[2];
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
-    assert!(tree.is_red(parent));
-
-    assert_eq!(tree.get_right(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_left(addrs[0]), grandparent);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(grandparent), addrs[0]);
-
-    assert_eq!(tree.get_right(grandparent), SENTINEL);
-    assert_eq!(tree.get_left(grandparent), parent);
-    assert_eq!(tree.get_parent(parent), grandparent);
-
-    let leaf = tree.insert(47, 0).unwrap();
-
-    assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(leaf));
-    assert!(tree.is_red(grandparent) && tree.is_red(parent));
-
-    assert_eq!(tree.get_right(addrs[0]), addrs[1]);
-    assert_eq!(tree.get_left(addrs[0]), leaf);
-    assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
-    assert_eq!(tree.get_parent(leaf), addrs[0]);
-
-    assert_eq!(tree.get_right(leaf), grandparent);
-    assert_eq!(tree.get_left(leaf), parent);
-    assert_eq!(tree.get_parent(grandparent), leaf);
-    assert_eq!(tree.get_parent(parent), leaf);
-    assert!(tree.is_leaf(parent) && tree.is_leaf(grandparent));
-    tree.pretty_print();
-}
-
-/// Test a power of 2 minus 1
-#[test]
-fn test_delete_multiple_random_1023() {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    type Rbt = RedBlackTree<u64, u64, 1023>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let mut keys = vec![];
-    // Fill up tree
-    for k in 0..1023 {
-        let mut hasher = DefaultHasher::new();
-        (k as u64).hash(&mut hasher);
-        let key = hasher.finish();
-        tree.insert(key, 0).unwrap();
-        keys.push(key);
-        assert!(tree.is_valid_red_black_tree());
-    }
-
-    for i in keys.iter() {
-        tree.remove(i).unwrap();
-        assert!(tree.is_valid_red_black_tree());
-    }
-}
-
-#[test]
-fn test_delete_multiple_random_1024() {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    type Rbt = RedBlackTree<u64, u64, 1024>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let mut keys = vec![];
-    let mut addrs = vec![];
-    // Fill up tree
-    for k in 0..1024 {
-        let mut hasher = DefaultHasher::new();
-        (k as u64).hash(&mut hasher);
-        let key = hasher.finish();
-        addrs.push(tree.insert(key, 0).unwrap());
-        keys.push(key);
-        assert!(tree.is_valid_red_black_tree());
-    }
-
-    for (k, a) in keys.iter().zip(addrs) {
-        assert!(tree.get_addr(k) == a);
-    }
-
-    for i in keys.iter() {
-        tree.remove(i).unwrap();
-        assert!(tree.is_valid_red_black_tree());
-    }
-}
-
-#[test]
-fn test_delete_multiple_random_2048() {
     use std::collections::{hash_map::DefaultHasher, BTreeMap};
     use std::hash::{Hash, Hasher};
-    type Rbt = RedBlackTree<u64, u64, 2048>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let mut keys = vec![];
-    // Fill up tree
-    for k in 0..2048 {
-        let mut hasher = DefaultHasher::new();
-        (k as u64).hash(&mut hasher);
-        let key = hasher.finish();
-        tree.insert(key, 0).unwrap();
-        keys.push(key);
+
+    #[test]
+    /// This test addresses the case where a node's parent and uncle are both red.
+    /// This is resolved by coloring the parent and uncle black and the grandparent red.
+    fn test_insert_with_red_parent_and_uncle() {
+        type Rbt = RedBlackTree<u64, u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let addrs = [tree.insert(61, 0).unwrap(),
+            tree.insert(52, 0).unwrap(),
+            tree.insert(85, 0).unwrap(),
+            tree.insert(76, 0).unwrap(),
+            tree.insert(93, 0).unwrap()];
+
+        let parent = addrs[4];
+        let uncle = addrs[3];
+        let grandparent = addrs[2];
+
+        assert_eq!(tree.get_left(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_right(addrs[0]), grandparent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(grandparent), addrs[0]);
+
+        assert_eq!(tree.get_left(grandparent), uncle);
+        assert_eq!(tree.get_right(grandparent), parent);
+        assert_eq!(tree.get_parent(uncle), grandparent);
+        assert_eq!(tree.get_parent(parent), grandparent);
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
+        assert!(tree.is_red(uncle) && tree.is_red(parent));
+
+        let leaf = tree.insert(100, 0).unwrap();
+
+        assert!(
+            tree.is_black(addrs[0])
+                && tree.is_black(addrs[1])
+                && tree.is_black(uncle)
+                && tree.is_black(parent)
+        );
+        assert!(tree.is_red(grandparent) && tree.is_red(leaf));
     }
 
-    let key_to_index = keys
-        .iter()
-        .enumerate()
-        .map(|(i, k)| (*k, i as u64))
-        .collect::<BTreeMap<_, _>>();
+    #[test]
+    /// This test addresses the case where a node's parent (P) is red and uncle is black.
+    /// The new leaf (L) is the right child of the parent and the parent is the right
+    /// child of the grandparent (G).
+    ///
+    /// "P is right child of G and L is right child of P."
+    ///
+    /// We resolve this by rotating the grandparent left and then
+    /// fixing the colors.
+    fn test_right_insert_with_red_right_child_parent_and_black_uncle() {
+        type Rbt = RedBlackTree<u64, u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let addrs = [tree.insert(61, 0).unwrap(),
+            tree.insert(52, 0).unwrap(),
+            tree.insert(85, 0).unwrap(),
+            tree.insert(93, 0).unwrap()];
 
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let index_tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let mut index_keys = vec![];
+        let parent = addrs[3];
+        // Uncle is black as it is null
+        let grandparent = addrs[2];
 
-    for k in keys.iter() {
-        let key = key_to_index[k];
-        index_tree.insert(key, 0).unwrap();
-        index_keys.push(key);
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
+        assert!(tree.is_red(parent));
+
+        assert_eq!(tree.get_left(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_right(addrs[0]), grandparent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(grandparent), addrs[0]);
+
+        assert_eq!(tree.get_left(grandparent), SENTINEL);
+        assert_eq!(tree.get_right(grandparent), parent);
+        assert_eq!(tree.get_parent(parent), grandparent);
+
+        let leaf = tree.insert(100, 0).unwrap();
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(parent));
+        assert!(tree.is_red(grandparent) && tree.is_red(leaf));
+
+        assert_eq!(tree.get_left(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_right(addrs[0]), parent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(parent), addrs[0]);
+
+        assert_eq!(tree.get_left(parent), grandparent);
+        assert_eq!(tree.get_right(parent), leaf);
+        assert_eq!(tree.get_parent(grandparent), parent);
+        assert_eq!(tree.get_parent(leaf), parent);
+        assert!(tree.is_leaf(leaf) && tree.is_leaf(grandparent));
     }
 
-    assert!(index_tree.is_valid_red_black_tree());
-    for i in index_keys.iter() {
-        index_tree.remove(i).unwrap();
+    #[test]
+    /// This test addresses the case where a node's parent is red and uncle is black.
+    /// The new leaf is the left child of the parent and the parent is the right
+    /// child of the grandparent.
+    ///
+    /// "P is right child of G and L is left child of P."
+    ///
+    /// We resolve this by rotating the parent right then applying the same
+    /// algorithm as the previous test.
+    fn test_left_insert_with_red_right_child_parent_and_black_uncle() {
+        type Rbt = RedBlackTree<u64, u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let addrs = [tree.insert(61, 0).unwrap(),
+            tree.insert(52, 0).unwrap(),
+            tree.insert(85, 0).unwrap(),
+            tree.insert(93, 0).unwrap()];
+
+        let parent = addrs[3];
+        // Uncle is black as it is null
+        let grandparent = addrs[2];
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
+        assert!(tree.is_red(parent));
+
+        assert_eq!(tree.get_left(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_right(addrs[0]), grandparent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(grandparent), addrs[0]);
+
+        assert_eq!(tree.get_left(grandparent), SENTINEL);
+        assert_eq!(tree.get_right(grandparent), parent);
+        assert_eq!(tree.get_parent(parent), grandparent);
+
+        let leaf = tree.insert(87, 0).unwrap();
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(leaf));
+        assert!(tree.is_red(grandparent) && tree.is_red(parent));
+
+        assert_eq!(tree.get_left(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_right(addrs[0]), leaf);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(leaf), addrs[0]);
+
+        assert_eq!(tree.get_left(leaf), grandparent);
+        assert_eq!(tree.get_right(leaf), parent);
+        assert_eq!(tree.get_parent(grandparent), leaf);
+        assert_eq!(tree.get_parent(parent), leaf);
+        assert!(tree.is_leaf(parent) && tree.is_leaf(grandparent));
+    }
+
+    #[test]
+    /// This test addresses the case where a node's parent is red and uncle is black.
+    /// The new leaf is the left child of the parent and the parent is the left
+    /// child of the grandparent.
+    ///
+    /// "P is left child of G and L is left child of P."
+    ///
+    /// We resolve this by rotating the grandparent right and then
+    /// fixing the colors.
+    fn test_left_insert_with_red_left_child_parent_and_black_uncle() {
+        type Rbt = RedBlackTree<u64, u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let addrs = [tree.insert(61, 0).unwrap(),
+            tree.insert(85, 0).unwrap(),
+            tree.insert(52, 0).unwrap(),
+            tree.insert(41, 0).unwrap()];
+
+        let parent = addrs[3];
+        // Uncle is black as it is null
+        let grandparent = addrs[2];
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
+        assert!(tree.is_red(parent));
+
+        assert_eq!(tree.get_right(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_left(addrs[0]), grandparent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(grandparent), addrs[0]);
+
+        assert_eq!(tree.get_right(grandparent), SENTINEL);
+        assert_eq!(tree.get_left(grandparent), parent);
+        assert_eq!(tree.get_parent(parent), grandparent);
+
+        let leaf = tree.insert(25, 0).unwrap();
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(parent));
+        assert!(tree.is_red(grandparent) && tree.is_red(leaf));
+
+        assert_eq!(tree.get_right(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_left(addrs[0]), parent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(parent), addrs[0]);
+
+        assert_eq!(tree.get_right(parent), grandparent);
+        assert_eq!(tree.get_left(parent), leaf);
+        assert_eq!(tree.get_parent(grandparent), parent);
+        assert_eq!(tree.get_parent(leaf), parent);
+        assert!(tree.is_leaf(leaf) && tree.is_leaf(grandparent));
+    }
+
+    #[test]
+    /// This test addresses the case where a node's parent is red and uncle is black.
+    /// The new leaf is the right child of the parent and the parent is the left
+    /// child of the grandparent.
+    ///
+    /// "P is left child of G and L is right child of P."
+    ///
+    /// We resolve this by rotating the parent left then applying the same
+    /// algorithm as the previous test.
+    fn test_right_insert_with_red_left_child_parent_and_black_uncle() {
+        type Rbt = RedBlackTree<u64, u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let addrs = [tree.insert(61, 0).unwrap(),
+            tree.insert(85, 0).unwrap(),
+            tree.insert(52, 0).unwrap(),
+            tree.insert(41, 0).unwrap()];
+
+        let parent = addrs[3];
+        // Uncle is black as it is null
+        let grandparent = addrs[2];
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(grandparent));
+        assert!(tree.is_red(parent));
+
+        assert_eq!(tree.get_right(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_left(addrs[0]), grandparent);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(grandparent), addrs[0]);
+
+        assert_eq!(tree.get_right(grandparent), SENTINEL);
+        assert_eq!(tree.get_left(grandparent), parent);
+        assert_eq!(tree.get_parent(parent), grandparent);
+
+        let leaf = tree.insert(47, 0).unwrap();
+
+        assert!(tree.is_black(addrs[0]) && tree.is_black(addrs[1]) && tree.is_black(leaf));
+        assert!(tree.is_red(grandparent) && tree.is_red(parent));
+
+        assert_eq!(tree.get_right(addrs[0]), addrs[1]);
+        assert_eq!(tree.get_left(addrs[0]), leaf);
+        assert_eq!(tree.get_parent(addrs[1]), addrs[0]);
+        assert_eq!(tree.get_parent(leaf), addrs[0]);
+
+        assert_eq!(tree.get_right(leaf), grandparent);
+        assert_eq!(tree.get_left(leaf), parent);
+        assert_eq!(tree.get_parent(grandparent), leaf);
+        assert_eq!(tree.get_parent(parent), leaf);
+        assert!(tree.is_leaf(parent) && tree.is_leaf(grandparent));
+        tree.pretty_print();
+    }
+
+    /// Test a power of 2 minus 1
+    #[test]
+    fn test_delete_multiple_random_1023() {
+        type Rbt = RedBlackTree<u64, u64, 1023>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let mut keys = vec![];
+        // Fill up tree
+        for k in 0..1023 {
+            let mut hasher = DefaultHasher::new();
+            (k as u64).hash(&mut hasher);
+            let key = hasher.finish();
+            tree.insert(key, 0).unwrap();
+            keys.push(key);
+            assert!(tree.is_valid_red_black_tree());
+        }
+
+        for i in keys.iter() {
+            tree.remove(i).unwrap();
+            assert!(tree.is_valid_red_black_tree());
+        }
+    }
+
+    #[test]
+    fn test_delete_multiple_random_1024() {
+        type Rbt = RedBlackTree<u64, u64, 1024>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let mut keys = vec![];
+        let mut addrs = vec![];
+        // Fill up tree
+        for k in 0..1024 {
+            let mut hasher = DefaultHasher::new();
+            (k as u64).hash(&mut hasher);
+            let key = hasher.finish();
+            addrs.push(tree.insert(key, 0).unwrap());
+            keys.push(key);
+            assert!(tree.is_valid_red_black_tree());
+        }
+
+        for (k, a) in keys.iter().zip(addrs) {
+            assert!(tree.get_addr(k) == a);
+        }
+
+        for i in keys.iter() {
+            tree.remove(i).unwrap();
+            assert!(tree.is_valid_red_black_tree());
+        }
+    }
+
+    #[test]
+    fn test_delete_multiple_random_2048() {
+        type Rbt = RedBlackTree<u64, u64, 2048>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let mut keys = vec![];
+        // Fill up tree
+        for k in 0..2048 {
+            let mut hasher = DefaultHasher::new();
+            (k as u64).hash(&mut hasher);
+            let key = hasher.finish();
+            tree.insert(key, 0).unwrap();
+            keys.push(key);
+        }
+
+        let key_to_index = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| (*k, i as u64))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let index_tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let mut index_keys = vec![];
+
+        for k in keys.iter() {
+            let key = key_to_index[k];
+            index_tree.insert(key, 0).unwrap();
+            index_keys.push(key);
+        }
+
         assert!(index_tree.is_valid_red_black_tree());
+        for i in index_keys.iter() {
+            index_tree.remove(i).unwrap();
+            assert!(index_tree.is_valid_red_black_tree());
+        }
     }
-}
 
-#[test]
-fn test_delete_multiple_random_512() {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    type Rbt = RedBlackTree<u64, u64, 512>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let mut keys = vec![];
-    // Fill up tree
-    for k in 0..512 {
-        let mut hasher = DefaultHasher::new();
-        (k as u64).hash(&mut hasher);
-        let key = hasher.finish();
-        tree.insert(key, 0).unwrap();
-        keys.push(key);
-        assert!(tree.is_valid_red_black_tree());
+    #[test]
+    fn test_delete_multiple_random_512() {
+        type Rbt = RedBlackTree<u64, u64, 512>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let mut keys = vec![];
+        // Fill up tree
+        for k in 0..512 {
+            let mut hasher = DefaultHasher::new();
+            (k as u64).hash(&mut hasher);
+            let key = hasher.finish();
+            tree.insert(key, 0).unwrap();
+            keys.push(key);
+            assert!(tree.is_valid_red_black_tree());
+        }
+        for i in keys.iter() {
+            tree.remove(i).unwrap();
+            assert!(tree.is_valid_red_black_tree());
+        }
     }
-    for i in keys.iter() {
-        tree.remove(i).unwrap();
-        assert!(tree.is_valid_red_black_tree());
+
+    #[test]
+    fn test_delete_multiple_random_4098() {
+        type Rbt = RedBlackTree<u64, u64, 4098>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+        let mut keys = vec![];
+        // Fill up tree
+        for k in 0..4098 {
+            let mut hasher = DefaultHasher::new();
+            (k as u64).hash(&mut hasher);
+            let key = hasher.finish();
+            tree.insert(key, 0).unwrap();
+            keys.push(key);
+            assert!(tree.is_valid_red_black_tree());
+        }
+        for i in keys.iter() {
+            tree.remove(i).unwrap();
+            assert!(tree.is_valid_red_black_tree());
+        }
     }
-}
 
-#[test]
-fn test_delete_multiple_random_4098() {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    type Rbt = RedBlackTree<u64, u64, 4098>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-    let mut keys = vec![];
-    // Fill up tree
-    for k in 0..4098 {
-        let mut hasher = DefaultHasher::new();
-        (k as u64).hash(&mut hasher);
-        let key = hasher.finish();
-        tree.insert(key, 0).unwrap();
-        keys.push(key);
-        assert!(tree.is_valid_red_black_tree());
+    #[test]
+    fn remove_root() {
+        type Rbt = RedBlackTree<u64, u64, 4098>;
+        let mut buf = vec![0u8; core::mem::size_of::<Rbt>()];
+        let tree = Rbt::new_from_slice(buf.as_mut_slice());
+
+        // Returns none when empty
+        assert!(tree.remove_root().is_none());
+
+        tree._insert(1, 5);
+        tree._insert(2, 0);
+        tree._insert(0, 4);
+
+        // balanced tree should have 1 as root
+        let root = tree.remove_root().unwrap();
+        assert_eq!(root.key, 1);
+        assert_eq!(root.value, 5);
     }
-    for i in keys.iter() {
-        tree.remove(i).unwrap();
-        assert!(tree.is_valid_red_black_tree());
-    }
-}
-
-#[test]
-fn remove_root() {
-    type Rbt = RedBlackTree<u64, u64, 4098>;
-    let mut buf = vec![0u8; std::mem::size_of::<Rbt>()];
-    let tree = Rbt::new_from_slice(buf.as_mut_slice());
-
-    // Returns none when empty
-    assert!(tree.remove_root().is_none());
-
-    tree._insert(1, 5);
-    tree._insert(2, 0);
-    tree._insert(0, 4);
-
-    // balanced tree should have 1 as root
-    let root = tree.remove_root().unwrap();
-    assert_eq!(root.key, 1);
-    assert_eq!(root.value, 5);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,7 @@
+use alloc::collections::BTreeMap;
 use bytemuck::Pod;
 use bytemuck::Zeroable;
+use core::fmt::Debug;
 use itertools::Itertools;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
@@ -10,7 +12,8 @@ use rand::{self, Rng};
 use sokoban::node_allocator::FromSlice;
 use sokoban::node_allocator::NodeAllocatorMap;
 use sokoban::*;
-use std::collections::BTreeMap;
+
+extern crate alloc;
 
 const MAX_SIZE: usize = 20000;
 
@@ -37,17 +40,17 @@ impl Widget {
     }
 }
 
-fn simulate<K: std::fmt::Debug + Clone + Copy + Zeroable + Pod + Ord, T>(expect_sorted: bool)
+fn simulate<K: Debug + Clone + Copy + Zeroable + Pod + Ord, T>(expect_sorted: bool)
 where
     T: Copy + FromSlice + NodeAllocatorMap<K, Widget>,
     Standard: Distribution<K>,
 {
-    let mut buf = vec![0u8; std::mem::size_of::<T>()];
+    let mut buf = vec![0u8; core::mem::size_of::<T>()];
     let tree = T::new_from_slice(buf.as_mut_slice());
     println!(
         "{} Memory Size: {}, Capacity: {}",
-        std::any::type_name::<T>(),
-        std::mem::size_of::<T>(),
+        core::any::type_name::<T>(),
+        core::mem::size_of::<T>(),
         MAX_SIZE
     );
     let mut rng = thread_rng();
@@ -278,7 +281,7 @@ where
         }
     }
 
-    println!("{} Size: {}", std::any::type_name::<T>(), tree.len(),);
+    println!("{} Size: {}", core::any::type_name::<T>(), tree.len(),);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -15,8 +15,7 @@ use sokoban::*;
 
 extern crate alloc;
 
-const MAX_SIZE: usize = 10;
-// const MAX_SIZE: usize = 20000;
+const MAX_SIZE: usize = 20000;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -15,7 +15,8 @@ use sokoban::*;
 
 extern crate alloc;
 
-const MAX_SIZE: usize = 20000;
+const MAX_SIZE: usize = 10;
+// const MAX_SIZE: usize = 20000;
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
@@ -61,6 +62,7 @@ where
     for _ in 0..(MAX_SIZE) {
         let k = rng.gen::<K>();
         v = Widget::new_random(&mut rng);
+        println!("insert key: {:?}, {:?}", k, v);
         assert!(tree.insert(k, v).is_some());
         s += 1;
         assert!(s == tree.len());
@@ -76,6 +78,7 @@ where
     rand_keys.shuffle(&mut rng);
 
     for k in rand_keys.iter() {
+        println!("Removing key: {:?}", k);
         assert!(tree.remove(k).is_some());
         s -= 1;
         map.remove(k);


### PR DESCRIPTION
#### Problem

`sokoban` library is already `no_std` friendly but still isn't `no_std` compatible

#### Summary of Changes

- use `libc-print` instead of `println` macro from `std`
- use `foldhash::FixedState` instead of `DefaultHasher` from `std`
- use `const fn`
- bump deps
- run `clippy lint` and apply suggestions

cc @jarry-xiao 